### PR TITLE
Add notification for being too far away to deliver vehicle

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -339,6 +339,8 @@ RegisterNetEvent('qb-tow:client:TowVehicle', function()
                     local targetPos = GetEntityCoords(CurrentTow)
                     if #(targetPos - vector3(sharedConfig.locations["vehicle"].coords.x, sharedConfig.locations["vehicle"].coords.y, sharedConfig.locations["vehicle"].coords.z)) < 25.0 then
                         deliverVehicle(CurrentTow)
+                    else
+                        exports.qbx_core:Notify(locale("error.too_far_away"), 'error')
                     end
                 end
                 RemoveBlip(CurrentBlip2)


### PR DESCRIPTION


## Description

Improve the game experience and explain why the vehicle didn't get  despawned instead of letting the player keep why the vehicle didn't get deleted questioning

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
